### PR TITLE
Get req params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [0.3.0] - 2019-05-30
+## [0.4.0] - 2019-05-31
+
+### Meta
+
+- branch: get-req-params
+
+### TODO
+
+- parse params sent via request
+- use params in swapi get
+
+## [0.3.0] - 2019-05-30 - 2019-05-31
 
 ### Meta
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - branch: get-req-params
 
-### TODO
+### Added
 
-- parse params sent via request
-- use params in swapi get
+- routes.js: add resource param to route, `/swapi/:resource`
+- controllers.js: parse req.params and add :resource to swapi GET url
 
 ## [0.3.0] - 2019-05-30 - 2019-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-## [0.4.0] - 2019-05-31
+## [0.4.0] - 2019-06-01
 
 ### Meta
 

--- a/controllers/controllers.js
+++ b/controllers/controllers.js
@@ -8,8 +8,10 @@ exports.homePage = (req, res) => {
 
 exports.swapi = (req, res) => {
   const url = 'https://swapi.co/api/';
+  const resource = req.params.resource;
+
   axios
-    .get(`${url}planets/1/?format=json`)
+    .get(`${url}${resource}/?format=json`)
     .then(payload => payload.data)
     .then(data => {
       console.log('\n\n\nDATA is:::', data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-web-back-end",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "modern-web-back-end",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Back end source code for the TCAL 2019 workshop, Build a Front End! Build a Back End!: A guided hands-on tour of modern web development tools and concepts",
   "main": "server.js",
   "scripts": {

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -6,6 +6,6 @@ const router = express.Router();
 
 router.get('/', controller.homePage);
 
-router.get('/swapi', controller.swapi);
+router.get('/swapi/:resource', controller.swapi);
 
 module.exports = router;


### PR DESCRIPTION
This PR registers the `:resource` param on the swapi route, and res.send()s the data via controllers.js.

Closes #3 